### PR TITLE
Changed all instances of User to a String username in display user recipes use cases

### DIFF
--- a/src/use_case/display_favourite_recipe/DisplayFavouriteInputData.java
+++ b/src/use_case/display_favourite_recipe/DisplayFavouriteInputData.java
@@ -1,14 +1,13 @@
 package use_case.display_favourite_recipe;
 
-import entity.User;
 public class DisplayFavouriteInputData {
 
-    private final User user;
+    private final String username;
 
     /**
      * Creates an input data object with the given user.
-     * @param user the user whose favourite recipes we want to display.
+     * @param username the user whose favourite recipes we want to display.
      */
-    public DisplayFavouriteInputData(User user) { this.user = user; }
+    public DisplayFavouriteInputData(String username) { this.username = username; }
 
 }

--- a/src/use_case/display_favourite_recipe/DisplayFavouriteInteractor.java
+++ b/src/use_case/display_favourite_recipe/DisplayFavouriteInteractor.java
@@ -1,7 +1,6 @@
 package use_case.display_favourite_recipe;
 
 import entity.Recipe;
-import entity.User;
 import java.util.List;
 
 /**
@@ -10,23 +9,23 @@ import java.util.List;
 public class DisplayFavouriteInteractor implements DisplayFavouriteInputBoundary {
     private final DisplayFavouriteUserDataAccessInterface dataAccess;
     private final DisplayFavouriteOutputBoundary presenter;
-    private final User user;
+    private final String username;
 
     /**
      * Creates a new DisplayFavouriteInteractor object with the given data access, presenter and user.
      * @param dataAccess the data access object that retrieves the relevant recipes based on user.
      * @param presenter the presenter that will update the view with the relevant recipes.
-     * @param user the user whose favourite recipes we want to display.
+     * @param username the user whose favourite recipes we want to display.
      */
-    public DisplayFavouriteInteractor(DisplayFavouriteUserDataAccessInterface dataAccess, DisplayFavouriteOutputBoundary presenter, User user) {
+    public DisplayFavouriteInteractor(DisplayFavouriteUserDataAccessInterface dataAccess, DisplayFavouriteOutputBoundary presenter, String username) {
         this.dataAccess = dataAccess;
         this.presenter = presenter;
-        this.user = user;
+        this.username = username;
     }
 
     @Override
     public void execute(DisplayFavouriteInputData input) {
-        List<Recipe> recipes = dataAccess.getFavouriteRecipes(user);
+        List<Recipe> recipes = dataAccess.getFavouriteRecipes(username);
         DisplayFavouriteOutputData dataOutput = new DisplayFavouriteOutputData(recipes);
         presenter.prepareSuccessView(dataOutput);
     }

--- a/src/use_case/display_favourite_recipe/DisplayFavouriteUserDataAccessInterface.java
+++ b/src/use_case/display_favourite_recipe/DisplayFavouriteUserDataAccessInterface.java
@@ -1,17 +1,15 @@
 package use_case.display_favourite_recipe;
 
 import entity.Recipe;
-import entity.User;
-
 import java.util.List;
 
 public interface DisplayFavouriteUserDataAccessInterface {
 
     /**
      * Gets the favourite recipes of the given user.
-     * @param user the user whose favourite recipes to get.
+     * @param username the user whose favourite recipes to get.
      * @return the favourite recipes of the given user.
      */
-    List<Recipe> getFavouriteRecipes(User user);
+    List<Recipe> getFavouriteRecipes(String username);
 
 }

--- a/src/use_case/display_tagged_recipe/DisplayTaggedInputData.java
+++ b/src/use_case/display_tagged_recipe/DisplayTaggedInputData.java
@@ -1,23 +1,21 @@
 package use_case.display_tagged_recipe;
 
 
-import entity.User;
-
 public class DisplayTaggedInputData {
-    private final User user;
+    private final String username;
     private final String tag;
 
     /** Creates an input data object with the given user and tag.
-     * @param user the user whose tagged recipes we want to display.
+     * @param username the user whose tagged recipes we want to display.
      * @param tag the tag to filter recipes we want to display.
      */
-    public DisplayTaggedInputData(User user, String tag) {
-        this.user = user;
+    public DisplayTaggedInputData(String username, String tag) {
+        this.username = username;
         this.tag = tag;
     }
 
-    public User getUser() {
-        return user;
+    public String getUser() {
+        return username;
     }
 
     public String getTag() {

--- a/src/use_case/display_tagged_recipe/DisplayTaggedUserDataAccessInterface.java
+++ b/src/use_case/display_tagged_recipe/DisplayTaggedUserDataAccessInterface.java
@@ -2,15 +2,14 @@ package use_case.display_tagged_recipe;
 
 import java.util.List;
 import entity.Recipe;
-import entity.User;
 
 public interface DisplayTaggedUserDataAccessInterface {
     /**
      * Gets the tagged recipes of the given user.
-     * @param user the user whose tagged recipes to get.
+     * @param username the user whose tagged recipes to get.
      * @param tag the tag to search for.
      * @return the tagged recipes of the given user.
      */
-    List<Recipe> getTaggedRecipes(User user, String tag);
+    List<Recipe> getTaggedRecipes(String username, String tag);
 
 }


### PR DESCRIPTION
This pull request changes all instances of User entity in the display user recipes use cases to a String username to avoid passing in an entity as the input data.