### PR TITLE
Make the JSON Persistence store the current User object

### DIFF
--- a/src/data_access/Persistence.java
+++ b/src/data_access/Persistence.java
@@ -1,7 +1,7 @@
 package data_access;
 
-/* TODO: this needs to be modified to include the interfaces from the other
- * use cases. */
+import use_case.display_favourite_recipe.DisplayFavouriteUserDataAccessInterface;
+import use_case.display_tagged_recipe.DisplayTaggedUserDataAccessInterface;
 
 /**
  * This interface functions as an aggregation of the interfaces defined by the
@@ -9,5 +9,5 @@ package data_access;
  * implemented by a Persistence class, and as a result that class implements
  * all the required functionality for the various use cases.
  */
-public interface Persistence {
+public interface Persistence extends DisplayFavouriteUserDataAccessInterface, DisplayTaggedUserDataAccessInterface {
 }

--- a/test/data_access/JSONPersistenceTest.java
+++ b/test/data_access/JSONPersistenceTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
 
 public class JSONPersistenceTest {
     private JSONPersistence instance;
-    private String filePath = "temp.json";
+    private final String filePath = "temp.json";
     private User filledUser;
     private User emptyUser;
 
@@ -64,7 +64,9 @@ public class JSONPersistenceTest {
     @Test
     public void testEmptyUserOutput() throws IOException {
         instance.save(emptyUser);
-        String fileContents = new String(Files.readAllBytes(Path.of(this.filePath)));
+        String fileContents = new String(Files.readAllBytes(
+                Path.of(String.valueOf(folder.getRoot()).concat("/" + this.filePath))
+        ));
         assertTrue(fileContents.contains("favourites"));
         assertTrue(fileContents.contains("tags"));
         assertTrue(fileContents.contains("{}"));
@@ -74,7 +76,9 @@ public class JSONPersistenceTest {
     @Test
     public void testSingleUserOutput() throws IOException {
         instance.save(filledUser);
-        String fileContents = new String(Files.readAllBytes(Path.of(this.filePath)));
+        String fileContents = new String(Files.readAllBytes(
+                Path.of(String.valueOf(folder.getRoot()).concat("/" + this.filePath))
+        ));
         /* Check that we have the right things in the contents of the files */
         assertTrue(fileContents.contains("asdf"));
         assertTrue(fileContents.contains("favourites"));


### PR DESCRIPTION
Closes #10. 

Uses a similar model to the Login CA example, where the DAO stores the information as instance variables, and the use cases access the DAO to get the information required.

Also update a method to use a more efficient technique of accessing the API to get the recipes associated with a list of IDs.