### PR TITLE
Quickfix: DAO `searchRecipesById` signature mismatch with interface

### DIFF
--- a/src/data_access/TheMealDB.java
+++ b/src/data_access/TheMealDB.java
@@ -27,7 +27,10 @@ public class TheMealDB implements RecipeAPI {
         this.recipeFactory = recipeFactory;
     }
     @Override
-    public Recipe searchRecipesById(String id) {
+    public Recipe searchRecipesById(int id) {
+        return searchRecipesById(String.valueOf(id));
+    }
+    private Recipe searchRecipesById(String id) {
         OkHttpClient client = new OkHttpClient().newBuilder().build();
         Request request = new Request.Builder()
                 .url(String.format(API_URL + "lookup.php?i=" + id))

--- a/test/data_access/TheMealDBTest.java
+++ b/test/data_access/TheMealDBTest.java
@@ -19,7 +19,7 @@ public class TheMealDBTest {
 
     @Test
     public void testCreateWithInvalidId() {
-        String id = "64920";
+        int id = 64920;
         Recipe recipe;
         recipe = instance.searchRecipesById(id);
         /* We expect a null returned if the recipe ID is invalid (i.e. doesn't exist). */
@@ -28,7 +28,7 @@ public class TheMealDBTest {
 
     @Test
     public void testCreateWithValidId() {
-        String id = "52772";
+        int id = 52772;
         Recipe recipe;
         recipe = instance.searchRecipesById(id);
         /* NOTE: we aren't testing for the contents, because that depends on the API, and may change. */


### PR DESCRIPTION
This should close and fix #27.