### PR TITLE
fixed tagged recipes use case to use hashmaps

### DIFF
--- a/src/use_case/display_tagged_recipe/DisplayTaggedInteractor.java
+++ b/src/use_case/display_tagged_recipe/DisplayTaggedInteractor.java
@@ -2,6 +2,8 @@ package use_case.display_tagged_recipe;
 
 import entity.Recipe;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -24,8 +26,28 @@ public class DisplayTaggedInteractor {
 
     public void execute(DisplayTaggedInputData input) {
         List<Recipe> recipes = dataAccess.getTaggedRecipes(dataAccess.getUser(), input.getTag());
-        DisplayTaggedOutputData dataOutput = new DisplayTaggedOutputData(recipes);
+        List<HashMap> recipesAsMaps = convertFromRecipeListToHashMapList(recipes);
+        DisplayTaggedOutputData dataOutput = new DisplayTaggedOutputData(recipesAsMaps);
 
         presenter.prepareSuccessView(dataOutput);
+    }
+
+    /**
+     * Converts the given list of recipes to a list of hash maps.
+     * @param recipes the recipes to convert.
+     * @return the given list of recipes as a list of hash maps.
+     */
+    private List<HashMap> convertFromRecipeListToHashMapList(List<Recipe> recipes) {
+        List<HashMap> recipesAsMaps = new ArrayList<>(recipes.size());
+        for (Recipe recipe: recipes) {
+            HashMap <String, String> recipeAsMap = new HashMap<>();
+            recipeAsMap.put("id", String.valueOf(recipe.getMealId()));
+            recipeAsMap.put("name", recipe.getName());
+            recipeAsMap.put("category", recipe.getCategory());
+            recipeAsMap.put("areaOfOrigin", recipe.getAreaOfOrigin());
+            recipeAsMap.put("instructions", recipe.getInstructions());
+            recipesAsMaps.add(recipeAsMap);
+        }
+        return recipesAsMaps;
     }
 }

--- a/src/use_case/display_tagged_recipe/DisplayTaggedOutputData.java
+++ b/src/use_case/display_tagged_recipe/DisplayTaggedOutputData.java
@@ -1,17 +1,17 @@
 package use_case.display_tagged_recipe;
 
+import java.util.HashMap;
 import java.util.List;
-import entity.Recipe;
 
 public class DisplayTaggedOutputData {
 
-    private final List<Recipe> recipes;
+    private final List<HashMap> recipes;
 
     /**
      * Creates an output data object with the given recipes.
      * @param recipes the recipes to display.
      */
-    public DisplayTaggedOutputData(List<Recipe> recipes) { this.recipes = recipes; }
+    public DisplayTaggedOutputData(List<HashMap> recipes) { this.recipes = recipes; }
 
-    public List<Recipe> getRecipes() { return recipes; }
+    public List<HashMap> getRecipes() { return recipes; }
 }


### PR DESCRIPTION
Quick PR that adds returning list of hashmap instead of list of recipes to tagged recipe use case. 

Same thing as I did for favourite recipe use case in previous PR, forgot to do it for tagged recipes earlier.