### PR TITLE
Fix issue of duplicate favourite recipes being allowed

### DIFF
--- a/src/entity/CommonRecipe.java
+++ b/src/entity/CommonRecipe.java
@@ -2,6 +2,7 @@ package entity;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 class CommonRecipe implements Recipe {
 
@@ -25,6 +26,19 @@ class CommonRecipe implements Recipe {
         this.category = category;
         this.instructions = instructions;
         this.areaOfOrigin = areaOfOrigin;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Recipe recipe = (Recipe) o;
+        return Objects.equals(mealId, recipe.getMealId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mealId);
     }
 
     @Override

--- a/src/use_case/favourite_recipe/FavouriteRecipeInteractor.java
+++ b/src/use_case/favourite_recipe/FavouriteRecipeInteractor.java
@@ -35,9 +35,14 @@ public class FavouriteRecipeInteractor implements FavouriteRecipeInputBoundary {
     @Override
     public void execute(FavouriteRecipeInputData favouriteRecipeInputData) {
         User user = jsonPersistence.getUser();
+        System.out.println(user.getFavourites().size());
         Recipe recipe = favouriteRecipeUserDataAccessObject.searchRecipesById(favouriteRecipeInputData.getMealId());
 
         ArrayList<Recipe> currentFavourites = user.getFavourites();
+        for (Recipe recipe1 : currentFavourites) {
+            System.out.println(recipe1.getName());
+        }
+
         if (currentFavourites.contains(recipe)) {
             favouriteRecipePresenter.prepareFailView(recipe.getName());
         } else {


### PR DESCRIPTION
This PR fixes the issue in our application that allowed for duplicate recipes to be favourited by overriding the equals method in the Recipe class to consider all recipe objects with the same meal id as equals.