### PR TITLE
Add tests for the Entity package

### DIFF
--- a/test/entity/CommonRecipeFactoryTest.java
+++ b/test/entity/CommonRecipeFactoryTest.java
@@ -1,0 +1,14 @@
+package entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonRecipeFactoryTest {
+    @Test
+    public void testConstruction() {
+        Recipe recipe1 = new CommonRecipe(12345, "recipe1", "test", "N/A", "testland");
+        Recipe recipe2 = new CommonRecipeFactory().create(12345, "recipe1", "test", "N/A", "testland");
+        assertEquals(recipe1, recipe2);
+    }
+}

--- a/test/entity/CommonRecipeTest.java
+++ b/test/entity/CommonRecipeTest.java
@@ -1,0 +1,49 @@
+package entity;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+
+public class CommonRecipeTest {
+    @Test
+    public void testEquality() {
+        Recipe recipe1 = new CommonRecipe(12345, "recipe1", "test", "N/A", "testland");
+        Recipe recipe2 = new CommonRecipe(12345, "recipe2", "test", "N/A", "testland");
+        assertEquals(recipe1, recipe2);
+
+        assertEquals(Objects.hash(12345), recipe1.hashCode());
+    }
+
+    @Test
+    public void testGetters() {
+        Recipe recipe = new CommonRecipe(12345, "recipe", "test", "nothing", "testland");
+
+        assertEquals(12345, recipe.getMealId());
+        assertEquals("recipe", recipe.getName());
+        assertEquals("test", recipe.getCategory());
+        assertEquals("nothing", recipe.getInstructions());
+        assertEquals("testland", recipe.getAreaOfOrigin());
+    }
+
+    @Test
+    public void testMapConversion() {
+        Map<String, String> expected = Map.ofEntries(
+                Map.entry("id", "12345"),
+                Map.entry("name", "recipe"),
+                Map.entry("category", "test"),
+                Map.entry("areaOfOrigin", "testland"),
+                Map.entry("instructions", "nothing")
+        );
+        Recipe recipe = new CommonRecipe(12345, "recipe", "test", "nothing", "testland");
+        Map<String, String> actual = recipe.toMap();
+
+        assertEquals(expected.size(), actual.size());
+        for (String key: expected.keySet()) {
+            assertEquals(expected.get(key), actual.get(key));
+        }
+    }
+}

--- a/test/entity/CommonUserFactoryTest.java
+++ b/test/entity/CommonUserFactoryTest.java
@@ -1,0 +1,16 @@
+package entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CommonUserFactoryTest {
+    @Test
+    public void testConstruction() {
+        User user1 = new CommonUser("test");
+        User user2 = new CommonUserFactory().create("test");
+        assertEquals(user1.getUsername(), user2.getUsername());
+        assertEquals(user1.getFavourites().size(), user2.getFavourites().size());
+        assertEquals(user1.getTaggedRecipes().size(), user2.getTaggedRecipes().size());
+    }
+}

--- a/test/entity/CommonUserTest.java
+++ b/test/entity/CommonUserTest.java
@@ -1,0 +1,47 @@
+package entity;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CommonUserTest {
+
+    private User user;
+
+    @Before
+    public void init() {
+        this.user = new CommonUser("test");
+    }
+    @Test
+    public void testGetters() {
+        assertEquals("test", user.getUsername());
+        assertEquals(0, user.getFavourites().size());
+        assertEquals(0, user.getTaggedRecipes().size());
+    }
+
+    @Test
+    public void testAddingNewTag() {
+        Recipe recipe = new CommonRecipe(12345, "test", "temp", "nothing", "testland");
+        user.assignTag(recipe, "tag1");
+        assertEquals(1, user.getTaggedRecipes().size());
+        assertEquals(1, user.getTaggedRecipes().get("tag1").size());
+    }
+
+    @Test
+    public void testAddingTExistingTag() {
+        Recipe recipe1 = new CommonRecipe(12345, "test", "temp", "nothing", "testland");
+        user.assignTag(recipe1, "tag1");
+        Recipe recipe2 = new CommonRecipe(67890, "test", "temp", "nothing", "testland");
+        user.assignTag(recipe2, "tag1");
+        assertEquals(1, user.getTaggedRecipes().size());
+        assertEquals(2, user.getTaggedRecipes().get("tag1").size());
+    }
+
+    @Test
+    public void testAddingFavourites() {
+        Recipe recipe = new CommonRecipe(12345, "test", "temp", "nothing", "testland");
+        user.addFavourite(recipe);
+        assertEquals(1, user.getFavourites().size());
+    }
+}


### PR DESCRIPTION
This should test the implementation of the four interfaces in the `Entity` package, i.e. `CommonUser`, `CommonUserFactory`, `CommonRecipe`, and `CommonRecipeFactory` (implementation of `User`, `UserFactory`, `Recipe`, and `RecipeFactory` respectively). 